### PR TITLE
Bind to a random UDP port

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -335,7 +335,7 @@ class TuyaLink {
       this.udpClient.on('listening', function () {
         this.setBroadcast(true);
       });
-      this.udpClient.bind(63145);
+      this.udpClient.bind(0);
     }
 
     // 0-filled buffer


### PR DESCRIPTION
Avoid situation in which port is already in use by some other 
application. Also allow running simultaneously multiple instances of 
clients trying to link to some devices.